### PR TITLE
Experimental - allowing zookeeper mode

### DIFF
--- a/kafka-native-test-container/src/test/java/com/ozangunalp/kraft/test/container/KafkaNativeContainerIT.java
+++ b/kafka-native-test-container/src/test/java/com/ozangunalp/kraft/test/container/KafkaNativeContainerIT.java
@@ -19,6 +19,7 @@ import org.testcontainers.utility.MountableFile;
 
 import com.ozangunalp.kraft.server.Endpoints;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.strimzi.test.container.StrimziZookeeperContainer;
 
 public class KafkaNativeContainerIT {
 
@@ -120,6 +121,19 @@ public class KafkaNativeContainerIT {
                                 " oauth.client.id=\"kafka-client\"" +
                                 " oauth.client.secret=\"kafka-client-secret\"" +
                                 " oauth.token.endpoint.uri=\"http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/token\";"));
+            }
+        }
+    }
+    
+    @Test
+    void testZookeeperContainer() {
+        try (StrimziZookeeperContainer zookeeper = new StrimziZookeeperContainer()) {
+            zookeeper.start();
+            try (var container = new KafkaNativeContainer()
+                    .withNetwork(Network.SHARED)
+                    .withArgs("-Dkafka.zookeeper.connect=zookeeper:2181")) {
+                container.start();
+                checkProduceConsume(container);
             }
         }
     }

--- a/kraft-server/src/main/java/com/ozangunalp/kraft/server/BrokerConfig.java
+++ b/kraft-server/src/main/java/com/ozangunalp/kraft/server/BrokerConfig.java
@@ -69,23 +69,31 @@ public final class BrokerConfig {
             props.put(KafkaConfig.BrokerIdProp(), brokerId);
         }
 
-        // Configure kraft
-        props.putIfAbsent(KafkaConfig.ProcessRolesProp(), "broker,controller");
-        props.putIfAbsent(KafkaConfig.QuorumVotersProp(), brokerId + "@" + controller.host() + ":" + controller.port());
+
+        boolean zookeeper = props.containsKey(KafkaConfig.ZkConnectProp());
+        if (!zookeeper) {
+            // Configure kraft
+            props.putIfAbsent(KafkaConfig.ProcessRolesProp(), "broker,controller");
+            props.putIfAbsent(KafkaConfig.QuorumVotersProp(), brokerId + "@" + controller.host() + ":" + controller.port());
+        }
 
 
-        if (!props.containsKey(KafkaConfig.ControllerListenerNamesProp()) ||
+        if (!(props.containsKey(KafkaConfig.ControllerListenerNamesProp()) || zookeeper) ||
                 !props.containsKey(KafkaConfig.InterBrokerListenerNameProp()) ||
                 !props.containsKey(KafkaConfig.ListenersProp())) {
-            // Configure controller listener names
-            props.put(KafkaConfig.ControllerListenerNamesProp(), Endpoints.listenerName(controller));
-
             // Configure listeners
+            List<String> earlyStartListeners = new ArrayList<>();
+            earlyStartListeners.add(Endpoints.BROKER_PROTOCOL_NAME);
+
             Map<String, Endpoint> listeners = advertised.stream()
                     .map(l -> new Endpoint(l.listenerName().orElse(null), l.securityProtocol(), "", kafkaPort))
                     .collect(Collectors.toMap(Endpoints::listenerName, Function.identity()));
+            if (!zookeeper) {
+                earlyStartListeners.add(Endpoints.CONTROLLER_PROTOCOL_NAME);
+                props.put(KafkaConfig.ControllerListenerNamesProp(), Endpoints.listenerName(controller));
+                listeners.put(Endpoints.listenerName(controller), controller);
+            }
             listeners.put(Endpoints.listenerName(internal), internal);
-            listeners.put(Endpoints.listenerName(controller), controller);
 
             String listenersString = listeners.values().stream()
                     .map(Endpoints::toListenerString)
@@ -102,8 +110,7 @@ public final class BrokerConfig {
                     mergeSecurityProtocolMap(listeners, (String) v));
 
             // Configure early start listeners
-            props.put(KafkaConfig.EarlyStartListenersProp(),
-                    Endpoints.BROKER_PROTOCOL_NAME + "," + Endpoints.CONTROLLER_PROTOCOL_NAME);
+            props.put(KafkaConfig.EarlyStartListenersProp(), String.join(",", earlyStartListeners));
         } else {
             LOGGER.warnf("Broker configs %s, %s, %s, %s will not be configured automatically, " +
                             "make sure to provide necessary configuration manually.",
@@ -112,7 +119,7 @@ public final class BrokerConfig {
                     KafkaConfig.InterBrokerListenerNameProp(),
                     KafkaConfig.ListenerSecurityProtocolMapProp());
         }
-        
+
         // Configure advertised listeners
         String advertisedListenersString = advertised.stream()
                 .map(Endpoints::toListenerString)

--- a/kraft-server/src/main/java/com/ozangunalp/kraft/server/BrokerConfig.java
+++ b/kraft-server/src/main/java/com/ozangunalp/kraft/server/BrokerConfig.java
@@ -77,10 +77,13 @@ public final class BrokerConfig {
             props.putIfAbsent(KafkaConfig.QuorumVotersProp(), brokerId + "@" + controller.host() + ":" + controller.port());
         }
 
-
-        if (!(props.containsKey(KafkaConfig.ControllerListenerNamesProp()) || zookeeper) ||
-                !props.containsKey(KafkaConfig.InterBrokerListenerNameProp()) ||
-                !props.containsKey(KafkaConfig.ListenersProp())) {
+        // auto-configure listeners if
+        // - no zookeeper and no controller.listener.names config
+        // - no inter.broker.listener.name config : zookeeper or not
+        // - no listeners config : zookeeper or not
+        if ((!zookeeper && !props.containsKey(KafkaConfig.ControllerListenerNamesProp()))
+                || !props.containsKey(KafkaConfig.InterBrokerListenerNameProp())
+                || !props.containsKey(KafkaConfig.ListenersProp())) {
             // Configure listeners
             List<String> earlyStartListeners = new ArrayList<>();
             earlyStartListeners.add(Endpoints.BROKER_PROTOCOL_NAME);

--- a/kraft-server/src/test/java/com/ozangunalp/kraft/server/BrokerConfigTest.java
+++ b/kraft-server/src/test/java/com/ozangunalp/kraft/server/BrokerConfigTest.java
@@ -41,7 +41,6 @@ class BrokerConfigTest {
         assertThat(properties).containsEntry(KafkaConfig.EarlyStartListenersProp(), "BROKER,CONTROLLER");
         assertThat(properties).containsEntry(KafkaConfig.ListenerSecurityProtocolMapProp(), "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT");
     }
-
     @Test
     void testOverrideListeners() {
         Properties props = new Properties();
@@ -60,7 +59,7 @@ class BrokerConfigTest {
         assertThat(properties).containsEntry(KafkaConfig.AdvertisedListenersProp(), "SSL://:9092");
         assertThat(properties).containsEntry(KafkaConfig.ListenerSecurityProtocolMapProp(), "SSL:SSL,CONTROLLER:PLAINTEXT");
     }
-    
+
     @Test
     void testMergedSecurityProtocolMap() {
         Properties props = new Properties();
@@ -78,4 +77,39 @@ class BrokerConfigTest {
         assertThat(properties).containsEntry(KafkaConfig.ListenerSecurityProtocolMapProp(), "JWT:SSL,BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT");
     }
 
+    @Test
+    void testZookeeperEmptyOverride() {
+        Properties props = new Properties();
+        props.put(KafkaConfig.ZkConnectProp(), "localhost:2181");
+        Properties properties = BrokerConfig.defaultCoreConfig(props, "", 9092, 9093, 9094, PLAINTEXT);
+        assertThat(properties).containsEntry(KafkaConfig.BrokerIdProp(), "1");
+        assertThat(properties).doesNotContainKey(KafkaConfig.QuorumVotersProp());
+        assertThat(properties).doesNotContainKey(KafkaConfig.ProcessRolesProp());
+        assertThat(properties).doesNotContainKey(KafkaConfig.ControllerListenerNamesProp());
+        assertThat(properties).containsEntry(KafkaConfig.ListenersProp(), "BROKER://:9093,PLAINTEXT://:9092");
+        assertThat(properties).containsEntry(KafkaConfig.InterBrokerListenerNameProp(), "BROKER");
+        assertThat(properties).containsEntry(KafkaConfig.AdvertisedListenersProp(), "PLAINTEXT://:9092,BROKER://:9093");
+        assertThat(properties).containsEntry(KafkaConfig.EarlyStartListenersProp(), "BROKER");
+        assertThat(properties).containsEntry(KafkaConfig.ListenerSecurityProtocolMapProp(), "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT");
+    }
+
+    @Test
+    void testZookeeperOverride() {
+        Properties props = new Properties();
+        props.put(KafkaConfig.ZkConnectProp(), "localhost:2181");
+        props.put(KafkaConfig.AdvertisedListenersProp(), "SSL://:9092");
+        props.put(KafkaConfig.ListenersProp(), "SSL://:9092");
+        props.put(KafkaConfig.InterBrokerListenerNameProp(), "SSL");
+        props.put(KafkaConfig.ListenerSecurityProtocolMapProp(), "SSL:SSL");
+
+        Properties properties = BrokerConfig.defaultCoreConfig(props, "", 9092, 9093, 9094, PLAINTEXT);
+        assertThat(properties).containsEntry(KafkaConfig.BrokerIdProp(), "1");
+        assertThat(properties).doesNotContainKey(KafkaConfig.QuorumVotersProp());
+        assertThat(properties).doesNotContainKey(KafkaConfig.ProcessRolesProp());
+        assertThat(properties).doesNotContainKey(KafkaConfig.ControllerListenerNamesProp());
+        assertThat(properties).containsEntry(KafkaConfig.ListenersProp(), "SSL://:9092");
+        assertThat(properties).containsEntry(KafkaConfig.InterBrokerListenerNameProp(), "SSL");
+        assertThat(properties).containsEntry(KafkaConfig.AdvertisedListenersProp(), "SSL://:9092");
+        assertThat(properties).containsEntry(KafkaConfig.ListenerSecurityProtocolMapProp(), "SSL:SSL");
+    }
 }

--- a/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
+++ b/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
@@ -111,7 +111,6 @@ class KafkaServerExtensionProcessor {
         producer.produce(new RuntimeInitializedClassBuildItem("kafka.server.DelayedFetchMetrics$"));
         producer.produce(new RuntimeInitializedClassBuildItem("kafka.server.DelayedProduceMetrics$"));
         producer.produce(new RuntimeInitializedClassBuildItem("kafka.server.DelayedDeleteRecordsMetrics$"));
-        producer.produce(new RuntimeInitializedClassBuildItem("kafka.admin.AdminUtils$"));
     }
 
     @BuildStep
@@ -137,6 +136,15 @@ class KafkaServerExtensionProcessor {
                 "org.keycloak.jose.jwk.JWK",
                 "org.keycloak.json.StringOrArrayDeserializer",
                 "org.keycloak.json.StringListMapDeserializer"));
+    }
+
+    @BuildStep
+    private void zookeeper(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<RuntimeInitializedClassBuildItem> producer) {
+        producer.produce(new RuntimeInitializedClassBuildItem("kafka.admin.AdminUtils$"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
+                "sun.security.provider.ConfigFile",
+                "org.apache.zookeeper.ClientCnxnSocketNIO"));
     }
 
     @BuildStep

--- a/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
+++ b/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
@@ -111,6 +111,7 @@ class KafkaServerExtensionProcessor {
         producer.produce(new RuntimeInitializedClassBuildItem("kafka.server.DelayedFetchMetrics$"));
         producer.produce(new RuntimeInitializedClassBuildItem("kafka.server.DelayedProduceMetrics$"));
         producer.produce(new RuntimeInitializedClassBuildItem("kafka.server.DelayedDeleteRecordsMetrics$"));
+        producer.produce(new RuntimeInitializedClassBuildItem("kafka.admin.AdminUtils$"));
     }
 
     @BuildStep


### PR DESCRIPTION

@ozangunalp I'm trying to allow kafka native to run in ZK mode to allow for our full range of test cases. I am hitting the following issue when trying to create the native image:

I am inexperienced with graalvm so if you could give me a pointer or two on the best way to solve it. that would be appreciated.

```
14:32:14,369 INFO  [org.apa.zoo.com.X509Util] Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation
[2/7] Performing analysis...  [*]                                                                      (223.3s @ 2.02GB)
  16,011 (93.07%) of 17,203 classes reachable
  21,985 (61.28%) of 35,874 fields reachable
  69,731 (71.90%) of 96,988 methods reachable
     456 classes,    30 fields, and   829 methods registered for reflection

Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing kafka.admin.AdminUtils$.assignReplicasToBrokersRackUnaware(int, int, scala.collection.Iterable, int, int)
Parsing context:
   at kafka.admin.AdminUtils$.assignReplicasToBrokersRackUnaware(AdminUtils.scala:130)
   at kafka.admin.AdminUtils$.assignReplicasToBrokers(AdminUtils.scala:116)
   at kafka.server.ZkAdminManager.$anonfun$createTopics$1(ZkAdminManager.scala:175)
   at kafka.server.ZkAdminManager$$Lambda$3889/0x00000007c20eb1e8.apply(Unknown Source)
   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)

	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:152)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:104)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:83)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraph(MethodTypeFlow.java:65)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultSpecialInvokeTypeFlow.onObservedUpdate(DefaultSpecialInvokeTypeFlow.java:61)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.TypeFlow.update(TypeFlow.java:558)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:635)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:193)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:177)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool.externalHelpQuiescePool(ForkJoinPool.java:2104)
	at java.base/java.util.concurrent.ForkJoinPool.awaitQuiescence(ForkJoinPool.java:3321)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.complete(CompletionExecutor.java:243)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis.doTypeflow(PointsToAnalysis.java:692)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis.finish(PointsToAnalysis.java:680)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis.runAnalysis(PointsToAnalysis.java:736)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:731)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:564)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:521)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:407)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:585)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)
Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.util.Random. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
	at parsing kafka.admin.AdminUtils$.rand(AdminUtils.scala:28)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2506)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:105)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3367)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3319)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3164)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1138)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1030)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:84)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:79)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:261)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:38)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.AnalysisParsedGraph.parseBytecode(AnalysisParsedGraph.java:135)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsed(AnalysisMethod.java:685)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.phases.InlineBeforeAnalysisGraphDecoder.lookupEncodedGraph(InlineBeforeAnalysis.java:180)
	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.doInline(PEGraphDecoder.java:1162)
	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.tryInline(PEGraphDecoder.java:1145)
	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.trySimplifyInvoke(PEGraphDecoder.java:1003)
	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.handleInvoke(PEGraphDecoder.java:957)
	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.GraphDecoder.processNextNode(GraphDecoder.java:817)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.phases.InlineBeforeAnalysisGraphDecoder.processNextNode(InlineBeforeAnalysis.java:240)
	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.GraphDecoder.decode(GraphDecoder.java:548)
	at jdk.internal.vm.compiler/org.graalvm.compiler.replacements.PEGraphDecoder.decode(PEGraphDecoder.java:833)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.phases.InlineBeforeAnalysis.decodeGraph(InlineBeforeAnalysis.java:98)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:176)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:343)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:93)
	... 21 more
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.util.Random. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.DisallowedImageHeapObjectFeature.error(DisallowedImageHeapObjectFeature.java:173)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.image.DisallowedImageHeapObjects.check(DisallowedImageHeapObjects.java:62)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.DisallowedImageHeapObjectFeature.replacer(DisallowedImageHeapObjectFeature.java:149)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisUniverse.replaceObject(AnalysisUniverse.java:583)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.ameta.AnalysisConstantReflectionProvider.replaceObject(AnalysisConstantReflectionProvider.java:257)

```

