### PR TITLE
Added build file to create kafka images for each version in quay

### DIFF
--- a/.build/check-kafka-tag.sh
+++ b/.build/check-kafka-tag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Checking branch ${RELEASE_VERSION} against ${KAFKA_VERSION}"
+
+if [[ ! "${RELEASE_VERSION}" =~ ^.*-kafka-${KAFKA_VERSION} ]]; then
+  echo "::error Branch name does not contain the kafka version"
+  exit 1
+fi

--- a/.github/workflows/build-kafka-images.yml
+++ b/.github/workflows/build-kafka-images.yml
@@ -1,0 +1,60 @@
+---
+name: Build Kafka Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch from which to deploy the release'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: maven
+          server-id: ossrh
+          server-username: OSSRH_USERNAME # env variable for username in deploy
+          server-password: OSSRH_TOKEN # env variable for token in deploy
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+          overwrite-settings: false
+      - name: Set Image Tag
+        run: |
+          echo "BUILD_IMAGE_TAG=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+      - name: Build with Maven
+        run: |
+          mvn -s .github/ci-maven-settings.xml -B \
+            clean package -Dnative \
+            -Dquarkus.native.container-build=true \
+            -Dquarkus.container-image.build=true \
+            -Dquarkus.container-image.tag=latest-${BUILD_IMAGE_TAG}
+      - name: Integration Tests with Maven
+        run: |
+          mvn -s .github/ci-maven-settings.xml -B \
+            clean verify -Dtest-container \
+            -Dkafka-native-container-version=latest-${BUILD_IMAGE_TAG} \
+            -Dzookeeper-native-container-version=latest-${BUILD_IMAGE_TAG}
+      - name: Release Snapshots
+        run: |
+          mvn -s .github/ci-maven-settings.xml -B \
+            clean deploy -DskipTests -Prelease
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          tags: quay.io/ogunalp/kafka-native:latest-${{ env.BUILD_IMAGE_TAG }} quay.io/ogunalp/zookeeper-native:latest-${{ env.BUILD_IMAGE_TAG }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.github/workflows/build-kafka-images.yml
+++ b/.github/workflows/build-kafka-images.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'The branch from which to deploy the release'
+        description: 'The branch from which to deploy the release, must follow [project-version]-kafka-[kafka-version]'
         required: true
 
 jobs:
@@ -29,32 +29,41 @@ jobs:
           overwrite-settings: false
       - name: Set Image Tag
         run: |
-          echo "BUILD_IMAGE_TAG=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          KAFKA_VERSION=$(mvn help:evaluate -Dexpression=kafka.version -q -DforceStdout)
+          echo "BUILD_IMAGE_TAG=${RELEASE_VERSION}" >> $GITHUB_ENV
+          echo "LATEST_IMAGE_TAG=latest-kafka-${KAFKA_VERSION}" >> $GITHUB_ENV
+      - name: Check Tag name
+        run: .build/check-kafka-tag.sh
       - name: Build with Maven
         run: |
           mvn -s .github/ci-maven-settings.xml -B \
             clean package -Dnative \
             -Dquarkus.native.container-build=true \
             -Dquarkus.container-image.build=true \
-            -Dquarkus.container-image.tag=latest-${BUILD_IMAGE_TAG}
+            -Dquarkus.container-image.tag=${{ env.BUILD_IMAGE_TAG }} \
+            -Dquarkus.container-image.additional-tags=${{ env.LATEST_IMAGE_TAG }}
       - name: Integration Tests with Maven
         run: |
           mvn -s .github/ci-maven-settings.xml -B \
             clean verify -Dtest-container \
-            -Dkafka-native-container-version=latest-${BUILD_IMAGE_TAG} \
-            -Dzookeeper-native-container-version=latest-${BUILD_IMAGE_TAG}
-      - name: Release Snapshots
-        run: |
-          mvn -s .github/ci-maven-settings.xml -B \
-            clean deploy -DskipTests -Prelease
-        env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Push To quay.io
-        id: push-to-quay
+            -Dkafka-native-container-version=${{ env.BUILD_IMAGE_TAG }} \
+            -Dzookeeper-native-container-version=${{ env.BUILD_IMAGE_TAG }}
+      - name: Push To quay.io kafka-native
+        id: push-to-quay-kafka
         uses: redhat-actions/push-to-registry@v2
         with:
-          tags: quay.io/ogunalp/kafka-native:latest-${{ env.BUILD_IMAGE_TAG }} quay.io/ogunalp/zookeeper-native:latest-${{ env.BUILD_IMAGE_TAG }}
+          registry: quay.io/ogunalp
+          image: kafka-native
+          tags: ${{ env.BUILD_IMAGE_TAG }} ${{ env.LATEST_IMAGE_TAG }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Push To quay.io zookeeper-native
+        id: push-to-quay-zookeeper
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          registry: quay.io/ogunalp
+          image: zookeeper-native
+          tags: ${{ env.BUILD_IMAGE_TAG }} ${{ env.LATEST_IMAGE_TAG }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -29,21 +29,24 @@ jobs:
           overwrite-settings: false
       - name: Set Release Version
         run: |
-          echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          KAFKA_VERSION=$(mvn help:evaluate -Dexpression=kafka.version -q -DforceStdout)
+          echo "BUILD_IMAGE_TAG=${RELEASE_VERSION}-kafka-${KAFKA_VERSION}" >> $GITHUB_ENV
+          echo "LATEST_IMAGE_TAG=latest-kafka-${KAFKA_VERSION}" >> $GITHUB_ENV
       - name: Build with Maven
         run: |
           mvn -s .github/ci-maven-settings.xml -B \
             clean package -Dnative \
             -Dquarkus.native.container-build=true \
             -Dquarkus.container-image.build=true \
-            -Dquarkus.container-image.tag=${RELEASE_VERSION} \
-            -Dquarkus.container-image.additional-tags=latest
+            -Dquarkus.container-image.tag=${{ env.BUILD_IMAGE_TAG }} \
+            -Dquarkus.container-image.additional-tags=latest,${{ env.LATEST_IMAGE_TAG }}
       - name: Integration Tests with Maven
         run: |
           mvn -s .github/ci-maven-settings.xml -B \
             clean verify -Dtest-container \
-            -Dkafka-native-container-version=${RELEASE_VERSION} \
-            -Dzookeeper-native-container-version=${RELEASE_VERSION}
+            -Dkafka-native-container-version=${{ env.BUILD_IMAGE_TAG }} \
+            -Dzookeeper-native-container-version=${{ env.BUILD_IMAGE_TAG }}
       - name: Release to Maven Central
         run: |
           mvn -s .github/ci-maven-settings.xml -B \
@@ -52,10 +55,21 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Push To quay.io
-        id: push-to-quay
+      - name: Push To quay.io kafka-native
+        id: push-to-quay-kafka
         uses: redhat-actions/push-to-registry@v2
         with:
-          tags: quay.io/ogunalp/kafka-native:latest quay.io/ogunalp/kafka-native:${{ env.RELEASE_VERSION }} quay.io/ogunalp/zookeeper-native:latest quay.io/ogunalp/zookeeper-native:${{ env.RELEASE_VERSION }}
+          registry: quay.io/ogunalp
+          image: kafka-native
+          tags: latest ${{ env.BUILD_IMAGE_TAG }} ${{ env.LATEST_IMAGE_TAG }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Push To quay.io zookeeper-native
+        id: push-to-quay-zookeeper
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          registry: quay.io/ogunalp
+          image: zookeeper-native
+          tags: latest ${{ env.BUILD_IMAGE_TAG }} ${{ env.LATEST_IMAGE_TAG }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <failsafe-plugin.version>3.0.0</failsafe-plugin.version>
         <release-plugin.version>3.0.0</release-plugin.version>
         <source-plugin.version>3.2.1</source-plugin.version>
+        <help-plugin.version>3.4.0</help-plugin.version>
         <javadoc-plugin.version>3.5.0</javadoc-plugin.version>
         <gpg-plugin.version>3.0.1</gpg-plugin.version>
         <nexus-staging-plugin.version>1.6.13</nexus-staging-plugin.version>
@@ -278,6 +279,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${source-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-help-plugin</artifactId>
+                    <version>${help-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jreleaser</groupId>


### PR DESCRIPTION
Continued from #41

-----

Changes the container image version scheme to `[project-version]-kafka-[kafka-version]`.

Different kafka versions can be released from `kafka/*` branches with the following workflow: 
- "Prepare release" action passing the required version as target branch: "[project-version]-kafka-[kafka-version]". This verifies that the kafka dependency is correct.
- "Build Kafka Images" action on the created release tag