### PR TITLE
Upgrade quarkus.native.builder-image to latest

### DIFF
--- a/kafka-server/src/main/resources/application.properties
+++ b/kafka-server/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.container-image.registry=quay.io
 quarkus.container-image.group=ogunalp
 quarkus.application.name=kafka-native
 quarkus.container-image.name=${quarkus.application.name}
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3.0-java17
+quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3.3-java17

--- a/zookeeper-server/src/main/resources/application.properties
+++ b/zookeeper-server/src/main/resources/application.properties
@@ -3,4 +3,4 @@ quarkus.container-image.registry=quay.io
 quarkus.container-image.group=ogunalp
 quarkus.application.name=zookeeper-native
 quarkus.container-image.name=${quarkus.application.name}
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3.0-java17
+quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3.3-java17


### PR DESCRIPTION
Why:
The build failed for me when running ` mvn package -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true `. The failure was at `quarkus-maven-plugin:2.16.5.Final:build (default) @ kafka-server`, the graal build crashed with message: `Fatal error: Failed while initializing the performance data.`

Which appears to be a known issue with 22.3.0 https://github.com/oracle/graal/issues/5303

Fixed for me by upgrading to the latest image