### PR TITLE
Make log-dir accessible for random UIDs

### DIFF
--- a/kafka-server/src/main/docker/Dockerfile.jvm
+++ b/kafka-server/src/main/docker/Dockerfile.jvm
@@ -85,7 +85,7 @@ COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
 COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
-RUN mkdir -p /deployments/target/log-dir
+RUN mkdir -m 777 -p /deployments/target/log-dir
 
 EXPOSE 9092
 USER 185

--- a/kafka-server/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-server/src/main/docker/Dockerfile.legacy-jar
@@ -82,7 +82,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/quarkus-run.jar
-RUN mkdir /deployments/target/log-dir
+RUN mkdir -m 777 -p /deployments/target/log-dir
 
 EXPOSE 9092
 USER 185

--- a/kafka-server/src/main/docker/Dockerfile.native
+++ b/kafka-server/src/main/docker/Dockerfile.native
@@ -23,6 +23,6 @@ COPY --chown=1001:root target/*-runner /work/kafka
 
 EXPOSE 9092
 USER 1001
-RUN mkdir -p /work/target/log-dir
+RUN mkdir -m 777 -p /work/target/log-dir
 
 CMD ["./kafka"]

--- a/kafka-server/src/main/docker/Dockerfile.native-micro
+++ b/kafka-server/src/main/docker/Dockerfile.native-micro
@@ -26,6 +26,6 @@ COPY --chown=1001:root target/*-runner /work/kafka
 
 EXPOSE 9092
 USER 1001
-RUN mkdir -p /work/target/log-dir
+RUN mkdir -m 777 -p /work/target/log-dir
 
 CMD ["./kafka"]


### PR DESCRIPTION
In OpenShift (DevSpaces/Che) container assigns a random UID. So make log-dir accessible for it when Kafka tries to create files.