### PR TITLE
Use the GraalVM 23 mandrel image to generate native images

### DIFF
--- a/kafka-server/src/main/resources/application.properties
+++ b/kafka-server/src/main/resources/application.properties
@@ -4,4 +4,5 @@ quarkus.container-image.registry=quay.io
 quarkus.container-image.group=ogunalp
 quarkus.application.name=kafka-native
 quarkus.container-image.name=${quarkus.application.name}
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3.3-java17
+quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
+quarkus.native.auto-service-loader-registration=true

--- a/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
+++ b/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
@@ -225,6 +225,7 @@ class KafkaServerExtensionProcessor {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(mechanismFactory).build());
         }
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("sun.security.jgss.GSSContextImpl").methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.apache.kafka.common.network.ListenerName[]").unsafeAllocated().build());
     }
 
     @BuildStep

--- a/zookeeper-server/src/main/resources/application.properties
+++ b/zookeeper-server/src/main/resources/application.properties
@@ -3,4 +3,5 @@ quarkus.container-image.registry=quay.io
 quarkus.container-image.group=ogunalp
 quarkus.application.name=zookeeper-native
 quarkus.container-image.name=${quarkus.application.name}
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3.3-java17
+quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
+quarkus.native.auto-service-loader-registration=true


### PR DESCRIPTION
`auto-service-loader-registration=true` was needed because jdk-provided login modules are no longer registered as services in native image. (Need reference)