### PR TITLE
Fix javadoc error introduced by 3fd9fa9694b399dd7bd76b2c51fcd72777cb01e8

### DIFF
--- a/kafka-server/src/main/java/com/ozangunalp/kafka/server/ServerConfig.java
+++ b/kafka-server/src/main/java/com/ozangunalp/kafka/server/ServerConfig.java
@@ -37,10 +37,10 @@ public interface ServerConfig {
      * List of scram credentials, separated by semicolon.
      * <br/>
      * Format of the scram string must be in one of the following forms:
-     * <plaintext>
+     * <pre>
      * SCRAM-SHA-256=[user=alice,password=alice-secret]
      * SCRAM-SHA-512=[user=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]
-     * </plaintext>
+     * </pre>
      *
      * @return list of scram credentials
      */


### PR DESCRIPTION
`mvn package -Prelease -DskipTests` is now locally with this change.