### PR TITLE
Replace deprecated quarkus.package.type

### DIFF
--- a/kafka-server/pom.xml
+++ b/kafka-server/pom.xml
@@ -138,7 +138,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
   </profiles>

--- a/kafka-server/src/main/docker/Dockerfile.legacy-jar
+++ b/kafka-server/src/main/docker/Dockerfile.legacy-jar
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package -Dquarkus.package.type=legacy-jar
+# ./mvnw package -Dquarkus.package.jar.type=legacy-jar
 #
 # Then, build the image with:
 #

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -117,7 +117,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
   </profiles>

--- a/zookeeper-server/src/main/docker/Dockerfile.legacy-jar
+++ b/zookeeper-server/src/main/docker/Dockerfile.legacy-jar
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package -Dquarkus.package.type=legacy-jar
+# ./mvnw package -Dquarkus.package.jar.type=legacy-jar
 #
 # Then, build the image with:
 #


### PR DESCRIPTION
why: compilation shows:

'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]