### PR TITLE
Fix LogSegment static init after 3.8.0

### DIFF
--- a/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
+++ b/quarkus-kafka-server-extension/deployment/src/main/java/com/ozangunalp/kafka/server/extension/deployment/KafkaServerExtensionProcessor.java
@@ -5,6 +5,7 @@ import static org.objectweb.asm.Opcodes.PUTSTATIC;
 import static org.objectweb.asm.Opcodes.ACONST_NULL;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.security.auth.spi.LoginModule;
 
@@ -352,6 +353,17 @@ class KafkaServerExtensionProcessor {
                         visitMethodInsn(INVOKESTATIC, "org/slf4j/LoggerFactory", "getLogger", "(Ljava/lang/Class;)Lorg/slf4j/Logger;", false);
                         // Store the result in the LOGGER field
                         visitFieldInsn(PUTSTATIC, Type.getInternalName(LogSegment.class), "LOGGER", "Lorg/slf4j/Logger;");
+
+                        // Load the string "-future"
+                        visitLdcInsn("-future");
+                        visitFieldInsn(PUTSTATIC, Type.getInternalName(LogSegment.class), "FUTURE_DIR_SUFFIX", "Ljava/lang/String;");
+                        // Load the string "^(\\S+)-(\\S+)\\.(\\S+)-future"
+                        visitLdcInsn("^(\\S+)-(\\S+)\\.(\\S+)-future");
+                        // Call Pattern.compile with the string
+                        visitMethodInsn(INVOKESTATIC, Type.getInternalName(Pattern.class), "compile", "(Ljava/lang/String;)Ljava/util/regex/Pattern;", false);
+                        // Store the result in FUTURE_DIR_PATTERN
+                        visitFieldInsn(PUTSTATIC, Type.getInternalName(LogSegment.class), "FUTURE_DIR_PATTERN", Type.getDescriptor(Pattern.class));
+
                         // Load null onto the stack
                         visitInsn(ACONST_NULL);
                         // Store null into LOG_FLUSH_TIMER field


### PR DESCRIPTION
Resolves #228

@k-wall I am not sure how I can reproduce the error case. but the generated bytecode is correct :
```
    private static final Logger LOGGER = LoggerFactory.getLogger(LogSegment.class);
    private static final Timer LOG_FLUSH_TIMER = null;
    private static final String FUTURE_DIR_SUFFIX = "-future";
    private static final Pattern FUTURE_DIR_PATTERN = Pattern.compile("^(\\S+)-(\\S+)\\.(\\S+)-future");
```