### PR TITLE
Use Java 21 in the GitHub workflows

### DIFF
--- a/.github/workflows/build-kafka-images.yml
+++ b/.github/workflows/build-kafka-images.yml
@@ -94,7 +94,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
       - name: Set Release Version & Image Tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
       - name: Set Image Tag
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
           server-id: ossrh

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -91,7 +91,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
       - name: Set Release Version & Image Tags
@@ -136,7 +136,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
           server-id: ossrh


### PR DESCRIPTION
why: release to Maven Central was failing as the toolchain java was lower than that required from the application.